### PR TITLE
Use a secure comparison in auth middleware

### DIFF
--- a/auth/basic.go
+++ b/auth/basic.go
@@ -11,7 +11,7 @@ func Basic(username string, password string) http.HandlerFunc {
 	var siteAuth = base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
 	return func(res http.ResponseWriter, req *http.Request) {
 		auth := req.Header.Get("Authorization")
-		if auth != "Basic "+siteAuth {
+		if !SecureCompare(auth, "Basic "+siteAuth) {
 			res.Header().Set("WWW-Authenticate", "Basic realm=\"Authorization Required\"")
 			http.Error(res, "Not Authorized", http.StatusUnauthorized)
 		}

--- a/auth/util.go
+++ b/auth/util.go
@@ -1,0 +1,15 @@
+package auth
+
+import (
+	"crypto/subtle"
+)
+
+// SecureCompare performs a constant time compare of two strings to limit timing attacks.
+func SecureCompare(given string, actual string) bool {
+	if subtle.ConstantTimeEq(int32(len(given)), int32(len(actual))) == 1 {
+		return subtle.ConstantTimeCompare([]byte(given), []byte(actual)) == 1
+	} else {
+		/* Securely compare actual to itself to keep constant time, but always return false */
+		return subtle.ConstantTimeCompare([]byte(actual), []byte(actual)) == 1 && false
+	}
+}

--- a/auth/util_test.go
+++ b/auth/util_test.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"testing"
+)
+
+var comparetests = []struct {
+	a   string
+	b   string
+	val bool
+}{
+	{"foo", "foo", true},
+	{"bar", "bar", true},
+	{"password", "password", true},
+	{"Foo", "foo", false},
+	{"foo", "foobar", false},
+	{"password", "pass", false},
+}
+
+func Test_SecureCompare(t *testing.T) {
+	for _, tt := range comparetests {
+		if SecureCompare(tt.a, tt.b) != tt.val {
+			t.Errorf("Expected SecureCompare(%v, %v) to return %v but did not", tt.a, tt.b, tt.val)
+		}
+	}
+}


### PR DESCRIPTION
Otherwise you might get timing attacks:

http://verboselogging.com/2012/08/20/a-timing-attack-in-action

I don't actually know Go.  I ran through gofmt at least.

Also I feel like that SecureCompare would be generally useful in a middleware project (Rack has one in Util ,for example) so I bet it should be extracted from here.
