### PR TITLE
Typo in doc

### DIFF
--- a/router.go
+++ b/router.go
@@ -13,7 +13,7 @@ type Params map[string]string
 type Router interface {
 	// Get adds a route for a HTTP GET request to the specified matching pattern.
 	Get(string, ...Handler)
-	// Ppst adds a route for a HTTP POST request to the specified matching pattern.
+	// Post adds a route for a HTTP POST request to the specified matching pattern.
 	Post(string, ...Handler)
 	// Put adds a route for a HTTP PUT request to the specified matching pattern.
 	Put(string, ...Handler)


### PR DESCRIPTION
Yup, that's it!

If you use [`golint`](https://github.com/golang/lint), it will warn you of things like that.  I've got it integrated in GoSublime (if you use Sublime Text), surely it must work with other editors.

Have a nice day!
