### PR TITLE
Re-use http.Dir for file handling

### DIFF
--- a/static.go
+++ b/static.go
@@ -3,18 +3,26 @@ package martini
 import (
 	"log"
 	"net/http"
-	"os"
-	"path/filepath"
 )
 
 // Static returns a middleware handler that serves static files in the given path.
 func Static(path string) Handler {
+	dir := http.Dir(path)
 	return func(res http.ResponseWriter, req *http.Request, log *log.Logger) {
-		file := filepath.Join(path, filepath.Clean(req.URL.Path))
-		info, err := os.Stat(file)
-		if err == nil && !info.IsDir() {
-			log.Println("[Static] Serving " + file)
-			http.ServeFile(res, req, file)
+		file := req.URL.Path
+		f, err := dir.Open(file)
+		if err != nil {
+			// discard the error?
+			return
 		}
+		defer f.Close()
+
+		fi, err := f.Stat()
+		if err != nil || fi.IsDir() {
+			return
+		}
+
+		log.Println("[Static] Serving " + file)
+		http.ServeContent(res, req, file, fi.ModTime(), f)
 	}
 }


### PR DESCRIPTION
I was mostly curious why you didn't use http.Dir. It handles some basic exploit checks etc.
