### PR TITLE
add buildtag to notify if go version < 1.1 #49

### DIFF
--- a/go_version.go
+++ b/go_version.go
@@ -1,0 +1,3 @@
+// +build !go1.1
+
+"martini requires go 1.1 or greater to build"


### PR DESCRIPTION
The output would look like this:

```
go_version.go:3:1: expected 'package', found 'STRING' "martini requires go 1.1 or greater to build"
```
