### PR TITLE
fixed serving default `index.html`

### DIFF
--- a/static.go
+++ b/static.go
@@ -25,7 +25,7 @@ func Static(path string) Handler {
 
 		// Try to serve index.html
 		if fi.IsDir() {
-			file = filepath.Join(file, "index.html")
+			file += "/index.html"
 			f, err = dir.Open(file)
 			if err != nil {
 				return


### PR DESCRIPTION
closes #68 

See [net/http](http://golang.org/src/pkg/net/http/fs.go#L314)
