### PR TITLE
Added a martini.ResponseWriter interface to make wrapping easier

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -12,36 +12,11 @@ func Logger() Handler {
 		start := time.Now()
 		log.Printf("Started %s %s", req.Method, req.URL.Path)
 
-		rl := &responseLogger{res, 200, 0}
-		c.MapTo(rl, (*http.ResponseWriter)(nil))
+		rw := NewResponseWriter(res)
+		c.MapTo(rw, (*http.ResponseWriter)(nil))
 
 		c.Next()
 
-		log.Printf("Completed %v %s in %v\n", rl.status, http.StatusText(rl.status), time.Now().Sub(start))
+		log.Printf("Completed %v %s in %v\n", rw.Status(), http.StatusText(rw.Status()), time.Now().Sub(start))
 	}
-}
-
-type responseLogger struct {
-	w      http.ResponseWriter
-	status int
-	size   int
-}
-
-func (l *responseLogger) Header() http.Header {
-	return l.w.Header()
-}
-
-func (l *responseLogger) Write(b []byte) (int, error) {
-	if l.status == 0 {
-		// The status will be StatusOK if WriteHeader has not been called yet
-		l.status = http.StatusOK
-	}
-	size, err := l.w.Write(b)
-	l.size += size
-	return size, err
-}
-
-func (l *responseLogger) WriteHeader(s int) {
-	l.w.WriteHeader(s)
-	l.status = s
 }

--- a/martini.go
+++ b/martini.go
@@ -70,7 +70,7 @@ func (m *Martini) Run() {
 }
 
 func (m *Martini) createContext(res http.ResponseWriter, req *http.Request) *context {
-	c := &context{inject.New(), append(m.handlers, m.action), &responseWriter{res, false}, 0}
+	c := &context{inject.New(), append(m.handlers, m.action), NewResponseWriter(res), 0}
 	c.SetParent(m)
 	c.MapTo(c, (*Context)(nil))
 	c.MapTo(c.rw, (*http.ResponseWriter)(nil))
@@ -118,7 +118,7 @@ type Context interface {
 type context struct {
 	inject.Injector
 	handlers []Handler
-	rw       *responseWriter
+	rw       ResponseWriter
 	index    int
 }
 
@@ -128,7 +128,7 @@ func (c *context) Next() {
 }
 
 func (c *context) written() bool {
-	return c.rw.written
+	return c.rw.Written()
 }
 
 func (c *context) run() {
@@ -139,27 +139,8 @@ func (c *context) run() {
 		}
 		c.index += 1
 
-		if c.rw.written {
+		if c.rw.Written() {
 			return
 		}
 	}
-}
-
-type responseWriter struct {
-	w       http.ResponseWriter
-	written bool
-}
-
-func (r *responseWriter) Header() http.Header {
-	return r.w.Header()
-}
-
-func (r *responseWriter) Write(b []byte) (int, error) {
-	r.written = true
-	return r.w.Write(b)
-}
-
-func (r *responseWriter) WriteHeader(s int) {
-	r.written = true
-	r.w.WriteHeader(s)
 }

--- a/response_writer.go
+++ b/response_writer.go
@@ -1,0 +1,56 @@
+package martini
+
+import (
+	"net/http"
+)
+
+// ResponseWriter is a wrapper around http.ResponseWriter that provides extra information about
+// the response. It is recommended that middleware handlers use this construct to wrap a responsewriter
+// if the functionality calls for it.
+type ResponseWriter interface {
+	http.ResponseWriter
+	// Status returns the status code of the response or 0 if the response has not been written.
+	Status() int
+	// Written returns whether or not the ResponseWriter has been written.
+	Written() bool
+	// Size returns the size of the response body.
+	Size() int
+}
+
+// NewResponseWriter creates a ResponseWriter that wraps an http.ResponseWriter
+func NewResponseWriter(rw http.ResponseWriter) ResponseWriter {
+	return &responseWriter{rw, 0, 0}
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	status int
+	size   int
+}
+
+func (rw *responseWriter) WriteHeader(s int) {
+	rw.ResponseWriter.WriteHeader(s)
+	rw.status = s
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	if !rw.Written() {
+		// The status will be StatusOK if WriteHeader has not been called yet
+		rw.status = http.StatusOK
+	}
+	size, err := rw.ResponseWriter.Write(b)
+	rw.size += size
+	return size, err
+}
+
+func (rw *responseWriter) Status() int {
+	return rw.status
+}
+
+func (rw *responseWriter) Size() int {
+	return rw.size
+}
+
+func (rw *responseWriter) Written() bool {
+	return rw.status != 0
+}

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -1,0 +1,44 @@
+package martini
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_ResponseWriter_WritingString(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	rw.Write([]byte("Hello world"))
+
+	expect(t, rec.Code, rw.Status())
+	expect(t, rec.Body.String(), "Hello world")
+	expect(t, rw.Status(), 200)
+	expect(t, rw.Size(), 11)
+	expect(t, rw.Written(), true)
+}
+
+func Test_ResponseWriter_WritingStrings(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	rw.Write([]byte("Hello world"))
+	rw.Write([]byte("foo bar bat baz"))
+
+	expect(t, rec.Code, rw.Status())
+	expect(t, rec.Body.String(), "Hello worldfoo bar bat baz")
+	expect(t, rw.Status(), 200)
+	expect(t, rw.Size(), 26)
+}
+
+func Test_ResponseWriter_WritingHeader(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	rw.WriteHeader(404)
+
+	expect(t, rec.Code, rw.Status())
+	expect(t, rec.Body.String(), "")
+	expect(t, rw.Status(), 404)
+	expect(t, rw.Size(), 0)
+}


### PR DESCRIPTION
I noticed this pattern was popping up more and more. We need a better (and safer) way to wrap http.ResponseWriter. This code would be a good jumping off point for #45 
