### PR TITLE
Allow route-handlers to run after response is modified 

### DIFF
--- a/martini.go
+++ b/martini.go
@@ -122,6 +122,7 @@ type Context interface {
 	// happen after an http request
 	Next()
 	written() bool
+	close()
 }
 
 type context struct {
@@ -140,15 +141,20 @@ func (c *context) written() bool {
 	return c.rw.Written()
 }
 
+func (c *context) close() {
+	c.rw.Close()
+}
+
 func (c *context) run() {
+
 	for c.index < len(c.handlers) {
 		_, err := c.Invoke(c.handlers[c.index])
 		if err != nil {
 			panic(err)
 		}
-		c.index += 1
 
-		if c.rw.Written() {
+		c.index += 1
+		if c.written() {
 			return
 		}
 	}

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -63,6 +63,18 @@ func Test_ResponseWriter_WritingHeader(t *testing.T) {
 	expect(t, rw.Size(), 0)
 }
 
+func Test_ResponseWriter_AfterClosed(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	rw.WriteHeader(200)
+	rw.Close()
+	rw.WriteHeader(500)
+
+	expect(t, rec.Code, rw.Status())
+	expect(t, rw.Status(), 200)
+}
+
 func Test_ResponseWriter_Hijack(t *testing.T) {
 	hijackable := newHijackableResponse()
 	rw := NewResponseWriter(hijackable)

--- a/router.go
+++ b/router.go
@@ -160,7 +160,7 @@ func (r *route) Handle(c Context, res http.ResponseWriter) {
 			res.Write([]byte(vals[0].String()))
 		}
 		if c.written() {
-			return
+			c.close()
 		}
 	}
 }

--- a/router_test.go
+++ b/router_test.go
@@ -130,18 +130,19 @@ func Test_RouterHandlerStacking(t *testing.T) {
 
 	f3 := func() string {
 		result += "bat"
-		return "Hello world"
+		return "It is only a paper moon"
 	}
 
-	f4 := func() {
+	f4 := func() string {
 		result += "baz"
+		return "Sailing over a cardboard sea"
 	}
 
 	router.Get("/foo", f1, f2, f3, f4)
 
 	router.Handle(recorder, req, context)
-	expect(t, result, "foobarbat")
-	expect(t, recorder.Body.String(), "Hello world")
+	expect(t, result, "foobarbatbaz")
+	expect(t, recorder.Body.String(), "It is only a paper moon")
 }
 
 var routeTests = []struct {


### PR DESCRIPTION
Martini does not allow middleware-/route-handlers to run once an earlier handler has modified the response. While it's generally good to protect us from doing silly things, it limits our ability to compose the flow that best suits our needs.

```
// ThingHandler invoked because logThing does not modify response
r.Get("/thing", logThing, ThingHandler)

// logThing never invoked because ThingHandler modifies response
r.Get("/thing", ThingHandler, logThing)
```

Reasons I would want to run _logThing_ after _ThingHandler_ include being able to react to, or log the HTTP status produced by the previous handler. One way I can do this now is with a middleware handler, which is convenient unless I only want to log this one route. Another way is to write this

```
r.Get("/thing", func(c martini.Context) {
  c.Invoke(ThingHandler)
  c.Invoke(logThing)
}
```

Which is fine but I'm working around a fragile Martini constraint, and I'm losing the benefits I get from running my handlers within the _route.Handle_ loop. We should be empowered to run handlers that we know are not modifying the response.
