### PR TITLE
Any method routing support for Martini

### DIFF
--- a/router.go
+++ b/router.go
@@ -26,6 +26,8 @@ type Router interface {
 	Delete(string, ...Handler) Route
 	// Options adds a route for a HTTP OPTIONS request to the specified matching pattern.
 	Options(string, ...Handler) Route
+	// Any adds a route for any HTTP method request to the specified matching pattern.
+	Any(string, ...Handler) Route
 
 	// NotFound sets the handler that is called when a no route matches a request. Throws a basic 404 by default.
 	NotFound(Handler)
@@ -66,6 +68,10 @@ func (r *router) Delete(pattern string, h ...Handler) Route {
 
 func (r *router) Options(pattern string, h ...Handler) Route {
 	return r.addRoute("OPTIONS", pattern, h)
+}
+
+func (r *router) Any(pattern string, h ...Handler) Route {
+	return r.addRoute("*", pattern, h)
 }
 
 func (r *router) Handle(res http.ResponseWriter, req *http.Request, context Context) {
@@ -132,8 +138,9 @@ func newRoute(method string, pattern string, handlers []Handler) *route {
 	return &route
 }
 
-func (r *route) Match(method string, path string) (bool, map[string]string) {
-	if method != r.method {
+func (r route) Match(method string, path string) (bool, map[string]string) {
+	// add Any method matching support
+	if r.method != "*" && method != r.method {
 		return false, nil
 	}
 


### PR DESCRIPTION
A new method `Any` is introduced to route certain urls of any methods to a `martini.Handler`.

``` go
// Any adds a route for any HTTP method request to the specified matching pattern.
Any(string, ...Handler)
```

With `Any` we could fully install martini upon martini, and thus other frameworks like `web.go` could be installed upon martini the same way. :)

``` go
package main

import (
    "github.com/Archs/martini"
    "github.com/Archs/martini-contrib/strip"
    "github.com/Archs/martini-contrib/web"
)

func main() {
    m := martini.Classic()

    m2 := martini.Classic()
    m2.Use(web.ContextWithCookieSecret(""))
    m2.Get("/", func() string {
        return "Hello World from 2nd martini"
    })

    m2.Get("/foo", func(ctx *web.Context) {
        ctx.ContentType("text/html")
        ctx.WriteString(html)
    })

    m2.Post("/foo", func() string {
        return "Welcome to Post"
    })

    m.Get("/", func() string {
        return "Hello World from 1st martini"
    })
        // Any to do the dirty tricks.
    m.Any("/2ndMartini/.*", strip.Prefix("/2ndMartini"), m2.ServeHTTP)

    m.Run()
}

const (
    html = `
    Hello Foo
<form action="foo" method="post">
    Inpu:<input type="text">
    <input type="submit" value="Submit">
</form>
`
)
```
