### PR TITLE
make govet golint happy

### DIFF
--- a/env.go
+++ b/env.go
@@ -4,6 +4,7 @@ import (
 	"os"
 )
 
+// Envs
 const (
 	Dev  string = "development"
 	Prod string = "production"
@@ -11,7 +12,7 @@ const (
 )
 
 // Env is the environment that Martini is executing in. The MARTINI_ENV is read on initialization to set this variable.
-var Env string = Dev
+var Env = Dev
 
 func setENV(e string) {
 	if len(e) > 0 {

--- a/go_version.go
+++ b/go_version.go
@@ -1,3 +1,5 @@
 // +build !go1.1
 
-"martini requires go 1.1 or greater to build"
+package martini
+
+// "martini requires go 1.1 or greater to build"

--- a/response_writer.go
+++ b/response_writer.go
@@ -73,7 +73,7 @@ func (rw *responseWriter) Before(before BeforeFunc) {
 func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hijacker, ok := rw.ResponseWriter.(http.Hijacker)
 	if !ok {
-		return nil, nil, fmt.Errorf("ResponseWriter doesn't support Hijacker interface")
+		return nil, nil, fmt.Errorf("the ResponseWriter doesn't support Hijacker interface")
 	}
 	return hijacker.Hijack()
 }


### PR DESCRIPTION
Another minor thing while I work on the tests. `go vet` and `golint` now report back clean. Mind you, I was curious what `the powers that be` wanted with `go_version.go`.

Cheers.
