### PR TITLE
Added HEAD HTTP method

### DIFF
--- a/router.go
+++ b/router.go
@@ -26,8 +26,8 @@ type Router interface {
 	Delete(string, ...Handler) Route
 	// Options adds a route for a HTTP OPTIONS request to the specified matching pattern.
 	Options(string, ...Handler) Route
-    // Head adds a route for a HTTP HEAD request to the specified matching pattern.
-    Head(string, ...Handler) Route
+	// Head adds a route for a HTTP HEAD request to the specified matching pattern.
+	Head(string, ...Handler) Route
 	// Any adds a route for any HTTP method request to the specified matching pattern.
 	Any(string, ...Handler) Route
 
@@ -73,7 +73,7 @@ func (r *router) Options(pattern string, h ...Handler) Route {
 }
 
 func (r *router) Head(pattern string, h ...Handler) Route {
-    return r.addRoute("HEAD", pattern, h)
+	return r.addRoute("HEAD", pattern, h)
 }
 
 func (r *router) Any(pattern string, h ...Handler) Route {

--- a/router_test.go
+++ b/router_test.go
@@ -51,7 +51,7 @@ func Test_Routing(t *testing.T) {
 		t.Error(err)
 	}
 	context7 := New().createContext(recorder, req7)
-    
+
 	req8, err := http.NewRequest("HEAD", "http://localhost:3000/wap//pow", nil)
 	if err != nil {
 		t.Error(err)
@@ -102,7 +102,7 @@ func Test_Routing(t *testing.T) {
 	router.Handle(recorder, req5, context5)
 	router.Handle(recorder, req6, context6)
 	router.Handle(recorder, req7, context7)
-    router.Handle(recorder, req8, context8)
+	router.Handle(recorder, req8, context8)
 	expect(t, result, "foobarbatbarfoofezpopbapwappowwappow")
 	expect(t, recorder.Code, http.StatusNotFound)
 	expect(t, recorder.Body.String(), "404 page not found\n")


### PR DESCRIPTION
I also fixed something I found at `router_test.go`

``` go
context7 := New().createContext(recorder, req6)
```

I assumed it was a typo and I changed it to 

``` go
context7 := New().createContext(recorder, req7)
```
