### PR TITLE
Added ReturnHandler to allow hooks to process return values

### DIFF
--- a/martini.go
+++ b/martini.go
@@ -37,7 +37,7 @@ type Martini struct {
 func New() *Martini {
 	m := &Martini{inject.New(), []Handler{}, func() {}, log.New(os.Stdout, "[martini] ", 0)}
 	m.Map(m.logger)
-	m.Map(ResponseEncoder(defaultResponseEncoder))
+	m.Map(ReturnHandler(defaultReturnHandler))
 	return m
 }
 

--- a/return_handler.go
+++ b/return_handler.go
@@ -5,13 +5,13 @@ import (
 	"reflect"
 )
 
-// ResponseEncoder is a service that Martini provides that is called
-// when a route handler returns something. The ResponseEncoder is
+// ReturnHandler is a service that Martini provides that is called
+// when a route handler returns something. The ReturnHandler is
 // responsible for writing to the ResponseWriter based on the values
 // that are passed into this function.
-type ResponseEncoder func(http.ResponseWriter, []reflect.Value)
+type ReturnHandler func(http.ResponseWriter, []reflect.Value)
 
-func defaultResponseEncoder(res http.ResponseWriter, vals []reflect.Value) {
+func defaultReturnHandler(res http.ResponseWriter, vals []reflect.Value) {
 	if len(vals) > 1 && vals[0].Kind() == reflect.Int {
 		res.WriteHeader(int(vals[0].Int()))
 		res.Write([]byte(vals[1].String()))

--- a/router.go
+++ b/router.go
@@ -246,9 +246,9 @@ func (r *routeContext) run() {
 		// if the handler returned something, write it to the http response
 		if len(vals) > 0 {
 			rv := r.Get(inject.InterfaceOf((*http.ResponseWriter)(nil)))
-			ev := r.Get(reflect.TypeOf(ResponseEncoder(nil)))
-			encode := ev.Interface().(ResponseEncoder)
-			encode(rv.Interface().(http.ResponseWriter), vals)
+			ev := r.Get(reflect.TypeOf(ReturnHandler(nil)))
+			handleReturn := ev.Interface().(ReturnHandler)
+			handleReturn(rv.Interface().(http.ResponseWriter), vals)
 		}
 
 		if r.written() {


### PR DESCRIPTION
This adds a service to Martini that will be used to encode the Return values coming from handlers. This does not change any behavior in Martini. It simply allows for custom return value handling if you want to do so. You can do it by mapping a `ReturnHandler` service in one of your handlers.

``` go
handler := func(rw http.ResponseWriter, vals []reflect.Value) {
  // handle the vals here
}

// map it as a service to override functionality
m.Map(martini.ReturnHandler(handler))
```
