### PR TITLE
Map martini.ResponseWriter in the injector as well

### DIFF
--- a/martini.go
+++ b/martini.go
@@ -84,6 +84,7 @@ func (m *Martini) createContext(res http.ResponseWriter, req *http.Request) *con
 	c.SetParent(m)
 	c.MapTo(c, (*Context)(nil))
 	c.MapTo(c.rw, (*http.ResponseWriter)(nil))
+	c.MapTo(c.rw, (*ResponseWriter)(nil))
 	c.Map(req)
 	return c
 }


### PR DESCRIPTION
I'm playing with some middleware that would like to know whether or not the response has been `Written()`
