### PR TITLE
Added support for []byte in the default return handler.

### DIFF
--- a/return_handler.go
+++ b/return_handler.go
@@ -13,11 +13,20 @@ type ReturnHandler func(http.ResponseWriter, []reflect.Value)
 
 func defaultReturnHandler() ReturnHandler {
 	return func(res http.ResponseWriter, vals []reflect.Value) {
+		var responseVal reflect.Value
 		if len(vals) > 1 && vals[0].Kind() == reflect.Int {
 			res.WriteHeader(int(vals[0].Int()))
-			res.Write([]byte(vals[1].String()))
+			responseVal = vals[1]
 		} else if len(vals) > 0 {
-			res.Write([]byte(vals[0].String()))
+			responseVal = vals[0]
+		}
+		if responseVal.Kind() == reflect.Interface || responseVal.Kind() == reflect.Ptr {
+			responseVal = responseVal.Elem()
+		}
+		if responseVal.Kind() == reflect.Slice && responseVal.Type().Elem().Kind() == reflect.Uint8 {
+			res.Write(responseVal.Bytes())
+		} else {
+			res.Write([]byte(responseVal.String()))
 		}
 	}
 }


### PR DESCRIPTION
I decided to submit pull request for this because I ended up coming across a bug (or might just violate POLA). (#127)

First off the pull request allows you to return a byte slice in the default return handler, which is useful if you returning marshaled json or anything else you might want to write that isn't a byte.

``` go
m.Get("/", func() []byte {
  return []byte("hello world") // HTTP 200 : "hello world"
})
```

Secondly, while doing this I came across the fact that if your return type is an `interface{}`, something unexpected (or I thought was unexpected) happens:

``` go
m.Get("/", func() interface{} {
  return "hello world" // HTTP 200 : "<interface {} Value>"
})
```

Martini will currently write 

```
<interface {} Value>
```

to the stream. This is fixed by getting the value the element points to using `Value.Elem()`
