### PR TITLE
Keep the params across all routers in a request

### DIFF
--- a/router.go
+++ b/router.go
@@ -84,7 +84,17 @@ func (r *router) Handle(res http.ResponseWriter, req *http.Request, context Cont
 	for _, route := range r.routes {
 		ok, vals := route.Match(req.Method, req.URL.Path)
 		if ok {
-			params := Params(vals)
+			var params Params
+			p := context.Get(reflect.TypeOf(Params(nil)))
+			if p.IsValid() {
+				params = p.Interface().(Params)
+			} else {
+				params = Params(make(map[string]string))
+			}
+
+			for k, v := range vals {
+				params[k] = v
+			}
 			context.Map(params)
 			r := routes{}
 			context.MapTo(r, (*Routes)(nil))


### PR DESCRIPTION
In the current code, the router.Handle overwrites the params and this makes it hard to create sub routers. This commit appends to the params rather than overwriting it. Only one param is created per context.
