### PR TITLE
Avoid parser errors with go_version.go

### DIFF
--- a/go_version.go
+++ b/go_version.go
@@ -1,3 +1,7 @@
 // +build !go1.1
 
-"martini requires go 1.1 or greater to build"
+package martini
+
+func MartiniDoesNotSupportGo1Point0() {
+	"Martini requires Go 1.1 or greater."
+}


### PR DESCRIPTION
@tobstarr Let me know if this with vim-godef. It should only throw a compiler error instead a parse error.
