### PR TITLE
Static assets should only be served for GET requests.

### DIFF
--- a/static.go
+++ b/static.go
@@ -11,6 +11,10 @@ import (
 func Static(directory string) Handler {
 	dir := http.Dir(directory)
 	return func(res http.ResponseWriter, req *http.Request, log *log.Logger) {
+		if req.Method != "GET" {
+			res.WriteHeader(http.StatusNotFound)
+		}
+
 		file := req.URL.Path
 		f, err := dir.Open(file)
 		if err != nil {

--- a/static_test.go
+++ b/static_test.go
@@ -22,6 +22,22 @@ func Test_Static(t *testing.T) {
 	expect(t, response.Code, http.StatusOK)
 }
 
+func Test_Static_As_Post(t *testing.T) {
+	response := httptest.NewRecorder()
+
+	m := New()
+
+	m.Use(Static("."))
+
+	req, err := http.NewRequest("POST", "http://localhost:3000/martini.go", nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	m.ServeHTTP(response, req)
+	expect(t, response.Code, http.StatusNotFound)
+}
+
 func Test_Static_BadDir(t *testing.T) {
 	response := httptest.NewRecorder()
 


### PR DESCRIPTION
Self explanatory - I think we should only serve the static assets for GET requests. What do you think?
