### PR TITLE
Fixes regression introduced by codegangsta/martini/pull/143

### DIFF
--- a/static.go
+++ b/static.go
@@ -11,14 +11,9 @@ import (
 func Static(directory string) Handler {
 	dir := http.Dir(directory)
 	return func(res http.ResponseWriter, req *http.Request, log *log.Logger) {
-		if req.Method != "GET" {
-			res.WriteHeader(http.StatusNotFound)
-			return
-		}
-
 		file := req.URL.Path
 		f, err := dir.Open(file)
-		if err != nil {
+		if err != nil || req.Method != "GET" {
 			// discard the error?
 			return
 		}

--- a/static_test.go
+++ b/static_test.go
@@ -26,8 +26,10 @@ func Test_Static_As_Post(t *testing.T) {
 	response := httptest.NewRecorder()
 
 	m := New()
+	r := NewRouter()
 
 	m.Use(Static("."))
+	m.Action(r.Handle)
 
 	req, err := http.NewRequest("POST", "http://localhost:3000/martini.go", nil)
 	if err != nil {


### PR DESCRIPTION
Hey @codegangsta, looks like I didn't test my earlier PR well enough. Caught a few mistakes. Explanation below with fixes. You can either revert that from master to test more throughly, or pull in this fix. Sorry about that. :cry: 

https://github.com/codegangsta/martini/pull/143.
1. The check for non-GET requests should occur after checking the static
   file is present. Otherwise, we are returning 404 for all non-GET
   requests.
2. We shouldn't set the status code to 404, as the router could override
   the behavior. GET localhost:3000 could serve index.html while POST
   localhost:3000 could respond with some custom response. If we returned
   404, you would not be able to override such behavior.
3. The router will handle returning 404 when there is no such override
   defined. Updated the test to use the router so it does.
