### PR TITLE
Add possibility to use a specific hostname

### DIFF
--- a/martini.go
+++ b/martini.go
@@ -74,9 +74,14 @@ func (m *Martini) Run() {
 	if len(port) == 0 {
 		port = "3000"
 	}
+	
+	host := os.Getenv("HOST")
+    	if len(host) == 0 {
+	    host = ""
+    	}
 
-	m.logger.Println("listening on port " + port)
-	m.logger.Fatalln(http.ListenAndServe(":"+port, m))
+	m.logger.Println("listening on host:port " + host + ":" + port)
+	m.logger.Fatalln(http.ListenAndServe(host+":"+port, m))
 }
 
 func (m *Martini) createContext(res http.ResponseWriter, req *http.Request) *context {


### PR DESCRIPTION
I'd like to add the possibility to listen to a specific hostname or IP address. This listens to the environment variable HOST and keeps it empty by default (so by default it works as before) but by assigning localhost to HOST it only listens to localhost.
