### PR TITLE
Recovey middleware : improve stacktrace

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -1,10 +1,12 @@
 package martini
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
-	"runtime/debug"
+	"runtime"
 )
 
 const (
@@ -38,6 +40,74 @@ pre {
 </html>`
 )
 
+var (
+	dunno     = []byte("???")
+	centerDot = []byte("·")
+	dot       = []byte(".")
+	slash     = []byte("/")
+)
+
+// stack returns a nicely formated stack frame, skipping skip frames
+func stack(skip int) []byte {
+	buf := new(bytes.Buffer) // the returned data
+	// As we loop, we open files and read them. These variables record the currently
+	// loaded file.
+	var lines [][]byte
+	var lastFile string
+	for i := skip; ; i++ { // Skip the expected number of frames
+		pc, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+		// Print this much at least.  If we can't find the source, it won't show.
+		fmt.Fprintf(buf, "%s:%d (0x%x)\n", file, line, pc)
+		if file != lastFile {
+			data, err := ioutil.ReadFile(file)
+			if err != nil {
+				continue
+			}
+			lines = bytes.Split(data, []byte{'\n'})
+			lastFile = file
+		}
+		fmt.Fprintf(buf, "\t%s: %s\n", function(pc), source(lines, line))
+	}
+	return buf.Bytes()
+}
+
+// source returns a space-trimmed slice of the n'th line.
+func source(lines [][]byte, n int) []byte {
+	n-- // in stack trace, lines are 1-indexed but our array is 0-indexed
+	if n < 0 || n >= len(lines) {
+		return dunno
+	}
+	return bytes.TrimSpace(lines[n])
+}
+
+// function returns, if possible, the name of the function containing the PC.
+func function(pc uintptr) []byte {
+	fn := runtime.FuncForPC(pc)
+	if fn == nil {
+		return dunno
+	}
+	name := []byte(fn.Name())
+	// The name includes the path name to the package, which is unnecessary
+	// since the file name is already included.  Plus, it has center dots.
+	// That is, we see
+	//	runtime/debug.*T·ptrmethod
+	// and want
+	//	*T.ptrmethod
+	// Also the package path might contains dot (e.g. code.google.com/...),
+	// so first eliminate the path prefix
+	if lastslash := bytes.LastIndex(name, slash); lastslash >= 0 {
+		name = name[lastslash+1:]
+	}
+	if period := bytes.Index(name, dot); period >= 0 {
+		name = name[period+1:]
+	}
+	name = bytes.Replace(name, centerDot, dot, -1)
+	return name
+}
+
 // Recovery returns a middleware that recovers from any panics and writes a 500 if there was one.
 // While Martini is in development mode, Recovery will also output the panic as HTML.
 func Recovery() Handler {
@@ -45,11 +115,12 @@ func Recovery() Handler {
 		defer func() {
 			if err := recover(); err != nil {
 				res.WriteHeader(http.StatusInternalServerError)
-				log.Printf("PANIC: %s\n%s", err, debug.Stack())
+				stack := stack(3)
+				log.Printf("PANIC: %s\n%s", err, stack)
 
 				// respond with panic message while in development mode
 				if Env == Dev {
-					res.Write([]byte(fmt.Sprintf(panicHtml, err, err, debug.Stack())))
+					res.Write([]byte(fmt.Sprintf(panicHtml, err, err, stack)))
 				}
 			}
 		}()


### PR DESCRIPTION
debug.Stack is not only deprecated (scheduled for removal), but also broken for package path containing dots (like "github.com/codegangsta/martini"...).
We fix this by introducing a private copy of debug.Stack that handles this (and also removes 1 more level of stackframe for cosmetic reasons).
