### PR TITLE
Maybe wrap this in a log.Fatal

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ To have more flexibility over port and host, use the `http.ListenAndServe` funct
 ~~~ go
   m := martini.Classic()
   // ...
-  http.ListenAndServe(":8080", m)
+  log.Fatal(http.ListenAndServe(":8080", m))
 ~~~
 
 ### Live code reload?


### PR DESCRIPTION
Otherwise you might miss the error: `2014/02/25 21:05:15 listen tcp :80: bind: permission denied`
