### PR TITLE
Added logging of response header to Martini Logger.

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -15,6 +15,7 @@ func Logger() Handler {
 		rw := res.(ResponseWriter)
 		c.Next()
 
+		log.Printf("Response header: %#v\n", rw.Header())
 		log.Printf("Completed %v %s in %v\n", rw.Status(), http.StatusText(rw.Status()), time.Since(start))
 	}
 }


### PR DESCRIPTION
Being able to see what the response header has in it can be very helpful to debug problems with your RESTful server.  This PR adds a dump of all the key-value pairs added to the header.

I'm thinking it would also be very useful sometimes to see the entire response.
