### PR TITLE
Fix using Regexp ASCII classes in route path.

### DIFF
--- a/router.go
+++ b/router.go
@@ -178,9 +178,16 @@ type route struct {
 
 func newRoute(method string, pattern string, handlers []Handler) *route {
 	route := route{method, nil, handlers, pattern, ""}
-	r := regexp.MustCompile(`:[^/#?()\.\\]+`)
+	// Prefect Regex would be `(?<!\[):[^\/#?()\.\\\]]+` but Regexp nor re2 support Negative Lookbehind.
+	r := regexp.MustCompile(`:[^/#?()\.\\\]]+`)
+	// Workaround for lack of Negative Lookbehind.
+	e := regexp.MustCompile(`:(alnum|alpha|ascii|blank|cntrl|digit|graph|lower|print|graph|punct|space|upper|word|xdigit)`)
 	pattern = r.ReplaceAllStringFunc(pattern, func(m string) string {
+		if e.MatchString(m){
+		  return m
+		} else {
 		return fmt.Sprintf(`(?P<%s>[^/#?]+)`, m[1:])
+		}
 	})
 	r2 := regexp.MustCompile(`\*\*`)
 	var index int


### PR DESCRIPTION
When using the ASCII classes in regex for routers, it failes with this error:

``` go
package main

import (
    "net/http"

    "github.com/codegangsta/martini"
)

func main() {
    m := martini.Classic()

    m.Get("/(?P<id>[:alnum:]+)", func(r *http.Request, params martini.Params) (int, string) {
        return 200, params["id"]
    })

    m.Run()
}

```

``` bash

$ go run main.go 
panic: regexp: Compile(`/(?P<id>[(?P<alnum:]+>[^/#?]+))\/?`): error parsing regexp: unexpected ): `/(?P<id>[(?P<alnum:]+>[^/#?]+))\/?`

goroutine 1 [running]:
runtime.panic(0x5d21c0, 0xc21000a770)
    /usr/lib64/golang/src/pkg/runtime/panic.c:266 +0xb6
regexp.MustCompile(0xc21001eb40, 0x22, 0x1f)
    /usr/lib64/golang/src/pkg/regexp/regexp.go:207 +0x141
github.com/codegangsta/martini.newRoute(0x67b580, 0x3, 0xc21004a680, 0x1f, 0xc21000a5e0, ...)
    /home/ome/microcloud/src/github.com/codegangsta/martini/router.go:192 +0x209
github.com/codegangsta/martini.(*router).addRoute(0xc21001f410, 0x67b580, 0x3, 0x69c610, 0x13, ...)
    /home/ome/microcloud/src/github.com/codegangsta/martini/router.go:141 +0x45a
github.com/codegangsta/martini.(*router).Get(0xc21001f410, 0x69c610, 0x13, 0xc21000a5e0, 0x1, ...)
    /home/ome/microcloud/src/github.com/codegangsta/martini/router.go:75 +0x75
main.main()
    //go/src/learning/main.go:14 +0xd7
exit status 2

```

This pull request will fix it.

TODO: include test case for these classes?
