### PR TITLE
Add Root path variable & add fix static middleware when app was started not from root folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ _testmain.go
 
 *.exe
 *.test
+
+/.godeps
+/.envrc

--- a/Godeps
+++ b/Godeps
@@ -1,0 +1,1 @@
+github.com/codegangsta/inject master

--- a/env.go
+++ b/env.go
@@ -2,6 +2,7 @@ package martini
 
 import (
 	"os"
+	"path/filepath"
 )
 
 // Envs
@@ -13,6 +14,7 @@ const (
 
 // Env is the environment that Martini is executing in. The MARTINI_ENV is read on initialization to set this variable.
 var Env = Dev
+var Root string
 
 func setENV(e string) {
 	if len(e) > 0 {
@@ -22,4 +24,9 @@ func setENV(e string) {
 
 func init() {
 	setENV(os.Getenv("MARTINI_ENV"))
+	path, err := filepath.Abs(os.Args[0])
+	if err != nil {
+		panic(err)
+	}
+	Root = filepath.Dir(path)
 }

--- a/env_test.go
+++ b/env_test.go
@@ -20,3 +20,9 @@ func Test_SetENV(t *testing.T) {
 		}
 	}
 }
+
+func Test_Root(t *testing.T) {
+	if len(Root) == 0 {
+		t.Errorf("Expected root path will be set")
+	}
+}

--- a/static.go
+++ b/static.go
@@ -44,6 +44,9 @@ func prepareStaticOptions(options []StaticOptions) StaticOptions {
 
 // Static returns a middleware handler that serves static files in the given directory.
 func Static(directory string, staticOpt ...StaticOptions) Handler {
+	if !path.IsAbs(directory) {
+		directory = path.Join(Root, directory)
+	}
 	dir := http.Dir(directory)
 	opt := prepareStaticOptions(staticOpt)
 


### PR DESCRIPTION
Currently, if you use something like monit, god or init.d tool for starting martini application(production server) you will get error because current directory is not root directory of martini application. This pull request will add Root variable and preprocess static middleware folder path. If path is absolute - nothing will happened. if local - root path will be prepended. The same problem right now has `render` middleware, so I think it should be added go core martini library, so than files related additions will reuse this code.

PS was added Godeps for easy dependencies managment  
