### PR TITLE
Fix martini.Root for `go test` & `go run` use cases

### DIFF
--- a/env.go
+++ b/env.go
@@ -3,6 +3,7 @@ package martini
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Envs
@@ -24,9 +25,20 @@ func setENV(e string) {
 
 func init() {
 	setENV(os.Getenv("MARTINI_ENV"))
+
 	path, err := filepath.Abs(os.Args[0])
 	if err != nil {
 		panic(err)
 	}
-	Root = filepath.Dir(path)
+	// In the dev mode when used commands `go test`, `go run` determining Root
+	// by a first argument is incorrect, because binary is putted into a temp directory.
+	// In these cases used a current directory as martini.Root
+	if strings.Contains(path, "go-build") && (strings.Contains(path, "command-line-arguments") || strings.Contains(path, "_test")) {
+		Root, err = os.Getwd()
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		Root = filepath.Dir(path)
+	}
 }

--- a/martini.go
+++ b/martini.go
@@ -81,6 +81,7 @@ func (m *Martini) Run() {
 	logger := m.Injector.Get(reflect.TypeOf(m.logger)).Interface().(*log.Logger)
 
 	logger.Printf("listening on %s:%s (%s)\n", host, port, Env)
+	logger.Printf("[Root] set to `%v`", Root)
 	logger.Fatalln(http.ListenAndServe(host+":"+port, m))
 }
 

--- a/static_test.go
+++ b/static_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http/httptest"
 	"testing"
 	"os"
-	"io/ioutil"
-	"path"
 
 	"github.com/codegangsta/inject"
 )
@@ -43,24 +41,16 @@ func Test_Static_Local_Path(t *testing.T) {
 
 	m := New()
 	r := NewRouter()
-
-	m.Use(Static("."))
-	f, err := ioutil.TempFile(Root, "static_content")
-	if err != nil {
-		t.Error(err)
-	}
-	f.WriteString("Expected Content")
-	f.Close()
+	m.Use(Static("translations"))
 	m.Action(r.Handle)
 
-	req, err := http.NewRequest("GET", "http://localhost:3000/" + path.Base(f.Name()), nil)
+	req, err := http.NewRequest("GET", "http://localhost:3000/README_ko_kr.md", nil)
 	if err != nil {
 		t.Error(err)
 	}
 	m.ServeHTTP(response, req)
 	expect(t, response.Code, http.StatusOK)
 	expect(t, response.Header().Get("Expires"), "")
-	expect(t, response.Body.String(), "Expected Content")
 }
 
 func Test_Static_Head(t *testing.T) {


### PR DESCRIPTION
fix for PR: https://github.com/go-martini/martini/pull/273 & issue https://github.com/go-martini/martini/issues/278
