### PR TITLE
Fix redirection of static resources to include query & fragment.

### DIFF
--- a/static.go
+++ b/static.go
@@ -3,6 +3,7 @@ package martini
 import (
 	"log"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 )
@@ -81,7 +82,12 @@ func Static(directory string, staticOpt ...StaticOptions) Handler {
 		if fi.IsDir() {
 			// redirect if missing trailing slash
 			if !strings.HasSuffix(req.URL.Path, "/") {
-				http.Redirect(res, req, req.URL.Path+"/", http.StatusFound)
+				dest := url.URL{
+					Path:     req.URL.Path + "/",
+					RawQuery: req.URL.RawQuery,
+					Fragment: req.URL.Fragment,
+				}
+				http.Redirect(res, req, dest.String(), http.StatusFound)
 				return
 			}
 

--- a/static_test.go
+++ b/static_test.go
@@ -221,12 +221,12 @@ func Test_Static_Redirect(t *testing.T) {
 	m := New()
 	m.Use(Static(currentRoot, StaticOptions{Prefix: "/public"}))
 
-	req, err := http.NewRequest("GET", "http://localhost:3000/public", nil)
+	req, err := http.NewRequest("GET", "http://localhost:3000/public?param=foo#bar", nil)
 	if err != nil {
 		t.Error(err)
 	}
 
 	m.ServeHTTP(response, req)
 	expect(t, response.Code, http.StatusFound)
-	expect(t, response.Header().Get("Location"), "/public/")
+	expect(t, response.Header().Get("Location"), "/public/?param=foo#bar")
 }


### PR DESCRIPTION
Previously, the static serving handler would allow automatically redirecting URLs that lacked a trailing slash to include the slash. However, these redirects were dropping any query and fragment portions of the URL.  This CL updates the redirect to include the entire redirect URL.
