### PR TITLE
martini.ResponseWriter includes http.Hijacker

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -13,6 +13,7 @@ import (
 type ResponseWriter interface {
 	http.ResponseWriter
 	http.Flusher
+	http.Hijacker
 	// Status returns the status code of the response or 0 if the response has not been written.
 	Status() int
 	// Written returns whether or not the ResponseWriter has been written.


### PR DESCRIPTION
Include http.Hijacker in the martini.ResponseWriter interface so that middleware like gzip will also implement Hijacker.
