### PR TITLE
Added RunOnAddr to listen on custom host:port

### DIFF
--- a/martini.go
+++ b/martini.go
@@ -69,19 +69,27 @@ func (m *Martini) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	m.createContext(res, req).run()
 }
 
+// Run the http server on a given host and port.
+func (m *Martini) RunOnAddr(addr string) {
+	// TODO: Should probably be implemented using a new instance of http.Server in place of
+	// calling http.ListenAndServer directly, so that it could be stored in the martini struct for later use.
+	// This would also allow to improve testing when a custom host and port are passed.
+
+	logger := m.Injector.Get(reflect.TypeOf(m.logger)).Interface().(*log.Logger)
+	logger.Printf("listening on %s (%s)\n", addr, Env)
+	logger.Fatalln(http.ListenAndServe(addr, m))
+}
+
 // Run the http server. Listening on os.GetEnv("PORT") or 3000 by default.
 func (m *Martini) Run() {
 	port := os.Getenv("PORT")
-	if port == "" {
+	if len(port) == 0 {
 		port = "3000"
 	}
 
 	host := os.Getenv("HOST")
 
-	logger := m.Injector.Get(reflect.TypeOf(m.logger)).Interface().(*log.Logger)
-
-	logger.Printf("listening on %s:%s (%s)\n", host, port, Env)
-	logger.Fatalln(http.ListenAndServe(host+":"+port, m))
+	m.RunOnAddr(host + ":" + port)
 }
 
 func (m *Martini) createContext(res http.ResponseWriter, req *http.Request) *context {

--- a/martini_test.go
+++ b/martini_test.go
@@ -27,8 +27,12 @@ func Test_New(t *testing.T) {
 	}
 }
 
-func Test_Martini_Run(t *testing.T) {
+func Test_Martini_RunOnAddr(t *testing.T) {
 	// just test that Run doesn't bomb
+	go New().RunOnAddr("127.0.0.1:8080")
+}
+
+func Test_Martini_Run(t *testing.T) {
 	go New().Run()
 }
 


### PR DESCRIPTION
Martini relied on global env variables to determine which host:port
address it would listen on. This is inconvenient for cases when more
than one instance is required. RunOnAddr has been added so that a
standard host:port string can be passed.
