### PR TITLE
New french translation, and documented RunOnAddr as the right method to change port/host

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,12 +358,12 @@ func init() {
 ### How do I change the port/host?
 
 Martini's `Run` function looks for the PORT and HOST environment variables and uses those. Otherwise Martini will default to localhost:3000.
-To have more flexibility over port and host, use the `http.ListenAndServe` function instead.
+To have more flexibility over port and host, use the `martini.RunOnAddr` function instead.
 
 ~~~ go
   m := martini.Classic()
   // ...
-  log.Fatal(http.ListenAndServe(":8080", m))
+  log.Fatal(m.RunOnAddr(":8080"))
 ~~~
 
 ### Live code reload?

--- a/translations/README_es_ES.md
+++ b/translations/README_es_ES.md
@@ -331,12 +331,12 @@ func init() {
 
 ### ¿Cómo cambiar el puerto/host?
 
-La función `Run` de Martini observa las variables PORT e HOST para utilizarlas. Caso contrário, Martini asume por defecto localhost:3000. Para tener maayor flexibilidad sobre el puerto y host, use la función `http.ListenAndServe`.
+La función `Run` de Martini observa las variables PORT e HOST para utilizarlas. Caso contrário, Martini asume por defecto localhost:3000. Para tener maayor flexibilidad sobre el puerto y host, use la función `martini.RunOnAddr`.
 
 ~~~ go
   m := martini.Classic()
   // ...
-  log.Fatal(http.ListenAndServe(":8080", m))
+  log.Fatal(m.RunOnAddr(":8080"))
 ~~~
 
 ### ¿Servidor con autoreload?

--- a/translations/README_fr_FR.md
+++ b/translations/README_fr_FR.md
@@ -324,12 +324,12 @@ func init() {
 ### Comment changer le port/adresse ?
 
 La fonction ```Run``` de Martini utilise le port et l'adresse spécifiés dans les variables d'environnement. Si elles ne peuvent y être trouvées, Martini utilisera *localhost:3000* par default.
-Pour avoir plus de flexibilité sur le port et l'adresse, utilisez la fonction `http.ListenAndServe` à la place.
+Pour avoir plus de flexibilité sur le port et l'adresse, utilisez la fonction `martini.RunOnAddr` à la place.
 
 ~~~ go
   m := martini.Classic()
   // ...
-  log.Fatal(http.ListenAndServe(":8080", m))
+  log.Fatal(m.RunOnAddr(":8080"))
 ~~~
 
 ### Rechargement du code en direct ?

--- a/translations/README_ja_JP.md
+++ b/translations/README_ja_JP.md
@@ -334,12 +334,12 @@ func init() {
 
 ### どうやってポート/ホストをかえるの?
 
-Martiniの`Run`関数はPORTとHOSTという環境変数を探し、その値を使用します。見つからない場合はlocalhost:3000がデフォルトで使用されます。もっと柔軟性をもとめるなら、`http.ListenAndServe`関数が役に立ちます:
+Martiniの`Run`関数はPORTとHOSTという環境変数を探し、その値を使用します。見つからない場合はlocalhost:3000がデフォルトで使用されます。もっと柔軟性をもとめるなら、`martini.RunOnAddr`関数が役に立ちます:
 
 ~~~ go
   m := martini.Classic()
   // ...
-  log.Fatal(http.ListenAndServe(":8080", m))
+  log.Fatal(m.RunOnAddr(":8080"))
 ~~~
 
 ### Live code reload?

--- a/translations/README_ko_kr.md
+++ b/translations/README_ko_kr.md
@@ -4,7 +4,7 @@
 
 ## 시작하기
 
-Go 설치 및 [GOPATH](http://golang.org/doc/code.html#GOPATH) 환경변수 설정 이후에, `.go` 파일 하나를 만들어 보죠..흠... 일단 `server.go`라고 부르겠습니다.
+Go 인스톨 및 [GOPATH](http://golang.org/doc/code.html#GOPATH) 환경변수 설정 이후에, `.go` 파일 하나를 만들어 보죠..흠... 일단 `server.go`라고 부르겠습니다.
 ~~~go
 package main
 
@@ -19,12 +19,12 @@ func main() {
 }
 ~~~
 
-마티니 패키지를 설치 합니다. (**go 1.1** 혹은 그 이상 버젼 필요):
+마티니 패키지를 인스톨 합니다. (**go 1.1** 혹은 그 이상 버젼 필요):
 ~~~
 go get github.com/go-martini/martini
 ~~~
 
-이제 서버를 실행해 봅시다:
+이제 서버를 돌려 봅시다:
 ~~~
 go run server.go
 ~~~
@@ -37,7 +37,7 @@ go run server.go
 
 [데모 비디오](http://martini.codegangsta.io/#demo)도 있어요.
 
-혹은 Stackoverflow에 [마티니 태그](http://stackoverflow.com/questions/tagged/martini)를 이용해서 물어봐 주세요
+혹은 Stackoverflow에 [마티니 태크](http://stackoverflow.com/questions/tagged/martini)를 이용해서 물어봐 주세요
 
 GoDoc [문서(documentation)](http://godoc.org/github.com/go-martini/martini)
 
@@ -53,7 +53,7 @@ GoDoc [문서(documentation)](http://godoc.org/github.com/go-martini/martini)
 * 끝내주는 경로 매칭과 라우팅.
 * 모듈 형 디자인 - 기능추가 쉽고, 코드 꺼내오기도 쉬움.
 * 쓸모있는 핸들러와 미들웨어가 많음.
-* 훌륭한 패키지화(out of the box) 기능들
+* 훌률한 패키지화(out of the box) 기능들
 * **[http.HandlerFunc](http://godoc.org/net/http#HandlerFunc) 인터페이스와 호환율 100%**
 
 ## 미들웨어(Middleware)
@@ -80,7 +80,7 @@ GoDoc [문서(documentation)](http://godoc.org/github.com/go-martini/martini)
 
 아래는 [martini.Classic()](http://godoc.org/github.com/go-martini/martini#Classic)의 자동으로 장착하는 기본 기능들입니다.
 
-  * 요청/응답 로그 기능 - [martini.Logger](http://godoc.org/github.com/go-martini/martini#Logger)
+  * Request/Response 로그 기능 - [martini.Logger](http://godoc.org/github.com/go-martini/martini#Logger)
   * 패닉 리커버리 (Panic Recovery) - [martini.Recovery](http://godoc.org/github.com/go-martini/martini#Recovery)
   * 정적 파일 서빙 - [martini.Static](http://godoc.org/github.com/go-martini/martini#Static)
   * 라우팅(Routing) - [martini.Router](http://godoc.org/github.com/go-martini/martini#Router)
@@ -120,7 +120,7 @@ m.Get("/", func(res http.ResponseWriter, req *http.Request) { // res와 req는 �
 ~~~
 
 아래 서비스들은 [martini.Classic()](http://godoc.org/github.com/go-martini/martini#Classic):에 포함되어 있습니다.
-  * [*log.Logger](http://godoc.org/log#Logger) - 마티니의 전역 로그.
+  * [*log.Logger](http://godoc.org/log#Logger) - 마티니의 글러벌(전역) 로그.
   * [martini.Context](http://godoc.org/github.com/go-martini/martini#Context) - http 요청 컨텍스트.
   * [martini.Params](http://godoc.org/github.com/go-martini/martini#Params) - 루트 매칭으로 찾은 인자를 `map[string]string`으로 변형.
   * [martini.Routes](http://godoc.org/github.com/go-martini/martini#Routes) - 루트 도우미 서미스.
@@ -160,7 +160,7 @@ m.NotFound(func() {
 })
 ~~~
 
-루트들은 정의된 순서대로 매칭된다. 들어온 요청에 첫번째 매칭된 루트가 호출된다.
+루트들은 정의된 순서대로 매칭된다. 들어온 요그에 첫번째 매칭된 루트가 호출된다.
 
 루트 패턴은 [martini.Params](http://godoc.org/github.com/go-martini/martini#Params) service로 액세스 가능한 인자들을 포함하기도 한다:
 ~~~ go
@@ -240,7 +240,7 @@ func MyCustomLoggerHandler(c martini.Context, req *http.Request) {
 ~~~ go
 func WrapResponseWriter(res http.ResponseWriter, c martini.Context) {
   rw := NewSpecialResponseWriter(res)
-  c.MapTo(rw, (*http.ResponseWriter)(nil)) // ResponseWriter를 NewResponseWriter로 오버라이드
+  c.MapTo(rw, (*http.ResponseWriter)(nil)) // ResponseWriter를 NewResponseWriter로 치환(override)
 }
 ~~~
 
@@ -286,19 +286,19 @@ m.Use(func(c martini.Context, log *log.Logger){
   log.Println("request전입니다.")
 
   c.Next()
-  
+
   log.Println("request후 입니다.")
 })
 ~~~
 
 ## Martini Env
-마티니 핸들러들은 `martini.Env` 글로벌 변수를 사용하여 개발환경에서는 프로덕션 환경과는 다르게 작동하기도 합니다. 따라서, 프로덕션 서버로 마티니 서버를 배포하시게 된다면 꼭 환경변수 `MARTINI_ENV=production`를 세팅해주시기 바랍니다.
+마티니 핸들러들은 `martini.Env` 글로벌 변수를 사용하여 개발환경에서는 프로덕션 환경과는 다르게 작동하기도 합니다. 따라서, 프로덕션 서버로 마티니 서보를 배포하시게 된다면 꼭 환경변수 `MARTINI_ENV=production`를 세팅해주시기 바랍니다.
 
 ## FAQ
 
 ### 미들웨어들을 어디서 찾아야 하나요?
 
-깃헙에서 [martini-contrib](https://github.com/martini-contrib) 프로젝트들을 찾아보세요. 만약에 못 찾으시겠으면, martini-contrib 팀원들에게 연락해서 하나 만들어 달라고 해보세요.
+깃헙에서 [martini-contrib](https://github.com/martini-contrib) 프로젝트들을 탖아보세요. 만약에 못 찾으시겠으면, martini-contrib 팀원들에게 연락해서 하나 만들어 달라고 해보세요.
 * [auth](https:	//github.com/martini-contrib/auth) - 인증작업을 도와주는 핸들러.
 * [binding](https://github.com/martini-contrib/binding) - request를 맵핑하고 검사하는 핸들러.
 * [gzip](https://github.com/martini-contrib/gzip) - gzip 핸들러.
@@ -336,12 +336,12 @@ func init() {
 ### 포트와 호스트는 어떻게 바꾸나요?
 
 마티니의 `Run` 함수는 PORT와 HOST 환경변수를 이용하는데, 설정이 안되어 있다면 localhost:3000으로 설정 되어 집니다.
-좀더 유연하게 설정을 하고 싶다면, `http.ListenAndServe`를 활용해 주세요.
+좀더 유연하게 설정을 하고 싶다면, `martini.RunOnAddr`를 활용해 주세요.
 
 ~~~ go
   m := martini.Classic()
   // ...
-  log.Fatal(http.ListenAndServe(":8080", m))
+  log.Fatal(m.RunOnAddr(":8080"))
 ~~~
 
 ### 라이브 포드 리로드?

--- a/translations/README_pt_br.md
+++ b/translations/README_pt_br.md
@@ -333,12 +333,12 @@ func init() {
 ### Como faço para alterar a porta/host?
 
 A função `Run` do Martini olha para as variáveis PORT e HOST para utilizá-las. Caso contrário o Martini assume como padrão localhost:3000.
-Para ter mais flexibilidade sobre a porta e host use a função `http.ListenAndServe`.
+Para ter mais flexibilidade sobre a porta e host use a função `martini.RunOnAddr`.
 
 ~~~ go
   m := martini.Classic()
   // ...
-  log.Fatal(http.ListenAndServe(":8080", m))
+  log.Fatal(m.RunOnAddr(":8080"))
 ~~~
 
 ### Servidor com autoreload?

--- a/translations/README_ru_RU.md
+++ b/translations/README_ru_RU.md
@@ -1,6 +1,6 @@
 # Martini  [![wercker status](https://app.wercker.com/status/9b7dbc6e2654b604cd694d191c3d5487/s/master "wercker status")](https://app.wercker.com/project/bykey/9b7dbc6e2654b604cd694d191c3d5487)[![GoDoc](https://godoc.org/github.com/go-martini/martini?status.png)](http://godoc.org/github.com/go-martini/martini)
 
-Martini - мощный пакет для быстрой разработки веб-приложений и сервисов на Golang.
+Martini - мощный пакет для быстрой разработки веб приложений и сервисов на Golang.
 
 ## Начало работы
 
@@ -62,7 +62,7 @@ GoDoc [документация](http://godoc.org/github.com/go-martini/martini)
   * [Роутинг](#%D0%A0%D0%BE%D1%83%D1%82%D0%B8%D0%BD%D0%B3)
   * [Сервисы](#%D0%A1%D0%B5%D1%80%D0%B2%D0%B8%D1%81%D1%8B)
   * [Отдача статических файлов](#%D0%9E%D1%82%D0%B4%D0%B0%D1%87%D0%B0-%D1%81%D1%82%D0%B0%D1%82%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%B8%D1%85-%D1%84%D0%B0%D0%B9%D0%BB%D0%BE%D0%B2)
-* [Middleware обработчики](#middleware-%D0%9E%D0%B1%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%87%D0%B8%D0%BA%D0%B8) 
+* [Middleware обработчики](#middleware-%D0%9E%D0%B1%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%87%D0%B8%D0%BA%D0%B8)
   * [Next()](#next)
 * [Окружение](#%D0%9E%D0%BA%D1%80%D1%83%D0%B6%D0%B5%D0%BD%D0%B8%D0%B5)
 * [FAQ](#faq)
@@ -91,14 +91,14 @@ m.Get("/", func() {
 ~~~
 
 #### Возвращаемые значения
-Если обработчик возвращает что-либо, Martini запишет это как результат в текущий [http.ResponseWriter](http://godoc.org/net/http#ResponseWriter), в виде строки: 
+Если обработчик возвращает что либо, Martini запишет это как результат в текущий [http.ResponseWriter](http://godoc.org/net/http#ResponseWriter), в виде строки:
 ~~~ go
 m.Get("/", func() string {
   return "hello world" // HTTP 200 : "hello world"
 })
 ~~~
 
-Также вы можете возвращать код статуса, опционально:
+Так же вы можете возвращать код статуса, опционально:
 ~~~ go
 m.Get("/", func() (int, string) {
   return 418, "i'm a teapot" // HTTP 418 : "i'm a teapot"
@@ -115,7 +115,7 @@ m.Get("/", func(res http.ResponseWriter, req *http.Request) { // res и req бу
 })
 ~~~
 
-Следующие сервисы включены в [martini.Classic()](http://godoc.org/github.com/go-martini/martini#Classic): 
+Следующие сервисы включены в [martini.Classic()](http://godoc.org/github.com/go-martini/martini#Classic):
 
   * [*log.Logger](http://godoc.org/log#Logger) - Глобальный логгер для Martini.
   * [martini.Context](http://godoc.org/github.com/go-martini/martini#Context) - http request контекст.
@@ -173,7 +173,7 @@ m.Get("/hello/**", func(params martini.Params) string {
 })
 ~~~
 
-Также могут использоваться регулярные выражения:
+Так же могут использоваться регулярные выражения:
 ~~~go
 m.Get("/hello/(?P<name>[a-zA-Z]+)", func(params martini.Params) string {
   return fmt.Sprintf ("Hello %s", params["name"])
@@ -181,14 +181,14 @@ m.Get("/hello/(?P<name>[a-zA-Z]+)", func(params martini.Params) string {
 ~~~
 Синтаксис регулярных выражений смотрите [Go documentation](http://golang.org/pkg/regexp/syntax/).
 
-Обработчики роутов также могут быть выстроены в стек, друг перед другом. Это очень удобно для таких задач как авторизация и аутентификация:
+Обработчики роутов так же могут быть выстроены в стек, друг перед другом. Это очень удобно для таких задач как авторизация и аутентификация:
 ~~~ go
 m.Get("/secret", authorize, func() {
   // будет вызываться, в случае если authorize ничего не записал в ответ
 })
 ~~~
 
-Роуты также могут быть объединены в группы, посредством метода Group:
+Роуты так же могут быть объединены в группы, посредством метода Group:
 ~~~ go
 m.Group("/books", func(r martini.Router) {
     r.Get("/:id", GetBooks)
@@ -287,7 +287,7 @@ m.Use(func(c martini.Context, log *log.Logger){
 ~~~
 
 ## Окружение
-Некоторые Martini обработчики используют глобальную переменную `martini.Env` для того, чтобы предоставить специальную функциональность для девелопмент и продакшн окружения. Рекомендуется устанавливать `MARTINI_ENV=production`, когда вы деплоите приложение на продакшн.
+Некоторые Martini обработчики используют глобальную переменную `martini.Env` для того, чтоб предоставить специальную функциональность для девелопмент и продакшн окружения. Рекомендуется устанавливать `MARTINI_ENV=production`, когда вы деплоите приложение на продакшн.
 
 ## FAQ
 
@@ -331,19 +331,19 @@ func init() {
 ### Как изменить порт и/или хост?
 Функция `Run` смотрит переменные окружиения PORT и HOST, и использует их.
 В противном случае Martini по умолчанию будет использовать `localhost:3000`.
-Для большей гибкости используйте вместо этого функцию `http.ListenAndServe`.
+Для большей гибкости используйте вместо этого функцию `martini.RunOnAddr`.
 
 ~~~ go
   m := martini.Classic()
   // ...
-  log.Fatal(http.ListenAndServe(":8080", m))
+  log.Fatal(m.RunOnAddr(":8080"))
 ~~~
 
 ### Живая перезагрузка кода?
 
 [gin](https://github.com/codegangsta/gin) и [fresh](https://github.com/pilu/fresh) могут работать вместе с Martini.
 
-## Вклад в общее дело
+## Вклад в обшее дело
 
 Подразумевается что Martini чистый и маленький. Большинство улучшений должны быть в организации [martini-contrib](https://github.com/martini-contrib). Но если вы хотите улучшить ядро Martini, отправляйте пулл реквесты.
 

--- a/translations/README_zh_cn.md
+++ b/translations/README_zh_cn.md
@@ -98,8 +98,8 @@ m.Get("/", func() (int, string) {
 })
 ~~~
 
-#### 服务的注入 
-处理器是通过反射来调用的. Martini 通过*Dependency Injection* *（依赖注入）* 来为处理器注入参数列表. **这样使得Martini与Go语言的`http.HandlerFunc`接口完全兼容.** 
+#### 服务的注入
+处理器是通过反射来调用的. Martini 通过*Dependency Injection* *（依赖注入）* 来为处理器注入参数列表. **这样使得Martini与Go语言的`http.HandlerFunc`接口完全兼容.**
 
 如果你加入一个参数到你的处理器, Martini将会搜索它参数列表中的服务，并且通过类型判断来解决依赖关系:
 ~~~ go
@@ -246,7 +246,7 @@ m.Use(func(c martini.Context, log *log.Logger){
   log.Println("before a request")
 
   c.Next()
-  
+
   log.Println("after a request")
 })
 ~~~
@@ -259,7 +259,7 @@ m.Use(func(c martini.Context, log *log.Logger){
 
 * [auth](https://github.com/martini-contrib/auth) - 认证处理器.
 * [binding](https://github.com/martini-contrib/binding) - 映射/验证raw请求到结构体(structure)里的处理器
-* [gzip](https://github.com/martini-contrib/gzip) - 加入gzip支持的处理器
+* [gzip](https://github.com/martini-contrib/gzip) - 加入giz支持的处理器
 * [render](https://github.com/martini-contrib/render) - 渲染JSON和HTML模板的处理器.
 * [acceptlang](https://github.com/martini-contrib/acceptlang) - 解析`Accept-Language` HTTP报头的处理器.
 * [sessions](https://github.com/martini-contrib/sessions) - 提供会话服务支持的处理器.
@@ -267,9 +267,6 @@ m.Use(func(c martini.Context, log *log.Logger){
 * [method](https://github.com/martini-contrib/method) - HTTP method overriding via Header or form fields.
 * [secure](https://github.com/martini-contrib/secure) - Implements a few quick security wins.
 * [encoder](https://github.com/martini-contrib/encoder) - Encoder service for rendering data in several formats and content negotiation.
-* [cors](https://github.com/martini-contrib/cors) - Handler that enables CORS support.
-* [oauth2](https://github.com/martini-contrib/oauth2) - Handler that provides OAuth 2.0 login for Martini apps. Google Sign-in, Facebook Connect and Github login is supported.
-* [vauth](https://github.com/rafecolton/vauth) - Handlers for vender webhook authentication (currently GitHub and TravisCI)
 
 ### 我如何整合到我现有的服务器中?
 
@@ -295,12 +292,12 @@ func init() {
 ### 我如何修改port/host?
 
 Martini的`Run`函数会检查PORT和HOST的环境变量并使用它们. 否则Martini将会默认使用localhost:3000
-如果想要自定义PORT和HOST, 使用`http.ListenAndServe`函数来代替.
+如果想要自定义PORT和HOST, 使用`martini.RunOnAddr`函数来代替.
 
 ~~~ go
   m := martini.Classic()
   // ...
-  http.ListenAndServe(":8080", m)
+  m.RunOnAddr(":8080")
 ~~~
 
 ## 贡献


### PR DESCRIPTION
The french translation was terrible and full of grammar mistakes. 

Also, the doc recommended the use of http.ListenAndServer to run Martini on a different host/port, while martini.RunOnAddr was designed for the same purpose.
