### PR TITLE
Change Serving Default Document Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ The following example serves the `/index.html` file whenever any URL is
 requested that does not match any local file and does not start with `/api/v`:
 ~~~ go
 static := martini.Static("assets", martini.StaticOptions{Fallback: "/index.html", Exclude: "/api/v"})
-r.NotFound(static, http.NotFound)
+m.NotFound(static, http.NotFound)
 ~~~
 
 ## Middleware Handlers


### PR DESCRIPTION
Change `r` to `m` for consistency.

`m` is used in all other examples to be the ClassicMartini struct. 
