### PR TITLE
[Proposal] router.Route shortcut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 
 /.godeps
 /.envrc
+
+.idea

--- a/README.md
+++ b/README.md
@@ -218,6 +218,17 @@ m.Group("/books", func(r martini.Router) {
 }, MyMiddleware1, MyMiddleware2)
 ~~~
 
+It's possible to define a route set to listen on different HTTP methods of a single route with the *Route* feature:
+~~~ go
+m.Route("/").Get(func() {
+    // show something
+}).Post(func() {
+    // create something
+}).Put(func() {
+    // replace something
+})
+~~~
+
 ### Services
 Services are objects that are available to be injected into a Handler's argument list. You can map a service on a *Global* or *Request* level.
 

--- a/router.go
+++ b/router.go
@@ -256,14 +256,14 @@ func newRoute(method string, pattern string, handlers []Handler) *route {
 	route := route{method, nil, handlers, pattern, ""}
 	r := regexp.MustCompile(`:[^/#?()\.\\]+`)
 	pattern = r.ReplaceAllStringFunc(pattern, func(m string) string {
-			return fmt.Sprintf(`(?P<%s>[^/#?]+)`, m[1:])
-		})
+		return fmt.Sprintf(`(?P<%s>[^/#?]+)`, m[1:])
+	})
 	r2 := regexp.MustCompile(`\*\*`)
 	var index int
 	pattern = r2.ReplaceAllStringFunc(pattern, func(m string) string {
-			index++
-			return fmt.Sprintf(`(?P<_%d>[^#?]*)`, index)
-		})
+		index++
+		return fmt.Sprintf(`(?P<_%d>[^#?]*)`, index)
+	})
 	pattern += `\/?`
 	route.regex = regexp.MustCompile(pattern)
 	return &route

--- a/router.go
+++ b/router.go
@@ -111,7 +111,6 @@ func (r *router) Route(pattern string) RouteSet {
 
 func (r *router) addRouteSet(pattern string) *routeset {
 	routeSet := newRouteSet(pattern, r)
-	//routeSet.Validate()
 	r.routeSets = append(r.routeSets, routeSet)
 	return routeSet
 }
@@ -193,23 +192,58 @@ type RouteSet interface {
 	// Get adds a route for a HTTP GET request to the specified matching pattern.
 	Get(...Handler) RouteSet
 	// Patch adds a route for a HTTP PATCH request to the specified matching pattern.
-	/*Patch(string, ...Handler) RouteSet
+	Patch(...Handler) RouteSet
 	// Post adds a route for a HTTP POST request to the specified matching pattern.
-	Post(string, ...Handler) RouteSet
+	Post(...Handler) RouteSet
 	// Put adds a route for a HTTP PUT request to the specified matching pattern.
-	Put(string, ...Handler) RouteSet
+	Put(...Handler) RouteSet
 	// Delete adds a route for a HTTP DELETE request to the specified matching pattern.
-	Delete(string, ...Handler) RouteSet
+	Delete(...Handler) RouteSet
 	// Options adds a route for a HTTP OPTIONS request to the specified matching pattern.
-	Options(string, ...Handler) RouteSet
+	Options(...Handler) RouteSet
 	// Head adds a route for a HTTP HEAD request to the specified matching pattern.
-	Head(string, ...Handler) RouteSet
+	Head(...Handler) RouteSet
 	// Any adds a route for any HTTP method request to the specified matching pattern.
-	Any(string, ...Handler) RouteSet*/
+	Any(...Handler) RouteSet
 }
 
 func (rs *routeset) Get(h ...Handler) RouteSet {
 	rs.router.addRoute("GET", rs.pattern, h)
+	return rs
+}
+
+func (rs *routeset) Patch(h ...Handler) RouteSet {
+	rs.router.addRoute("PATCH", rs.pattern, h)
+	return rs
+}
+
+func (rs *routeset) Post(h ...Handler) RouteSet {
+	rs.router.addRoute("POST", rs.pattern, h)
+	return rs
+}
+
+func (rs *routeset) Put(h ...Handler) RouteSet {
+	rs.router.addRoute("PUT", rs.pattern, h)
+	return rs
+}
+
+func (rs *routeset) Delete(h ...Handler) RouteSet {
+	rs.router.addRoute("DELETE", rs.pattern, h)
+	return rs
+}
+
+func (rs *routeset) Options(h ...Handler) RouteSet {
+	rs.router.addRoute("OPTIONS", rs.pattern, h)
+	return rs
+}
+
+func (rs *routeset) Head(h ...Handler) RouteSet {
+	rs.router.addRoute("HEAD", rs.pattern, h)
+	return rs
+}
+
+func (rs *routeset) Any(h ...Handler) RouteSet {
+	rs.router.addRoute("*", rs.pattern, h)
 	return rs
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -50,6 +50,30 @@ func Test_Routing(t *testing.T) {
 	req13, _ := http.NewRequest("GET", "http://localhost:3000/bazz/in/ga", nil)
 	context13 := New().createContext(recorder, req13)
 
+	routeGetReq, _ := http.NewRequest("GET", "http://localhost:3000/route", nil)
+	routeGetContext := New().createContext(recorder, routeGetReq)
+
+	routePostReq, _ := http.NewRequest("POST", "http://localhost:3000/route", nil)
+	routePostContext := New().createContext(recorder, routePostReq)
+
+	routePutReq, _ := http.NewRequest("PUT", "http://localhost:3000/route", nil)
+	routePutContext := New().createContext(recorder, routePutReq)
+
+	routePatchReq, _ := http.NewRequest("PATCH", "http://localhost:3000/route", nil)
+	routePatchContext := New().createContext(recorder, routePatchReq)
+
+	routeDeleteReq, _ := http.NewRequest("DELETE", "http://localhost:3000/route", nil)
+	routeDeleteContext := New().createContext(recorder, routeDeleteReq)
+
+	routeOptionsReq, _ := http.NewRequest("OPTIONS", "http://localhost:3000/route", nil)
+	routeOptionsContext := New().createContext(recorder, routeOptionsReq)
+
+	routeHeadReq, _ := http.NewRequest("HEAD", "http://localhost:3000/route", nil)
+	routeHeadContext := New().createContext(recorder, routeHeadReq)
+
+	routeGetParamsReq, _ := http.NewRequest("GET", "http://localhost:3000/route/66", nil)
+	routeGetParamsContext := New().createContext(recorder, routeGetParamsReq)
+
 	result := ""
 	router.Get("/foo", func(req *http.Request) {
 		result += "foo"
@@ -111,6 +135,27 @@ func Test_Routing(t *testing.T) {
 		result += "inga"
 	})
 
+	routeResult := ""
+	router.Route("/route").Get(func() {
+		routeResult += "gethead"
+	}).Post(func() {
+		routeResult += "post"
+	}).Put(func() {
+		routeResult += "put"
+	}).Patch(func() {
+		routeResult += "patch"
+	}).Delete(func() {
+		routeResult += "delete"
+	}).Options(func() {
+		routeResult += "options"
+	}).Head(func() {
+		routeResult += "gethead"
+	})
+	router.Route("/route/:route").Get(func(params Params) {
+		expect(t, params["route"], "66")
+		routeResult += "params"
+	})
+
 	router.Handle(recorder, req, context)
 	router.Handle(recorder, req2, context2)
 	router.Handle(recorder, req3, context3)
@@ -124,7 +169,16 @@ func Test_Routing(t *testing.T) {
 	router.Handle(recorder, req11, context11)
 	router.Handle(recorder, req12, context12)
 	router.Handle(recorder, req13, context13)
+	router.Handle(recorder, routeGetReq, routeGetContext)
+	router.Handle(recorder, routePostReq, routePostContext)
+	router.Handle(recorder, routePutReq, routePutContext)
+	router.Handle(recorder, routePatchReq, routePatchContext)
+	router.Handle(recorder, routeDeleteReq, routeDeleteContext)
+	router.Handle(recorder, routeOptionsReq, routeOptionsContext)
+	router.Handle(recorder, routeHeadReq, routeHeadContext)
+	router.Handle(recorder, routeGetParamsReq, routeGetParamsContext)
 	expect(t, result, "foobarbatbarfoofezpopbapwappowwappowoptsfoobazzingagetbazzingapostbazzingagroupception")
+	expect(t, routeResult, "getheadpostputpatchdeleteoptionsgetheadparams")
 	expect(t, recorder.Code, http.StatusNotFound)
 	expect(t, recorder.Body.String(), "404 page not found\n")
 }


### PR DESCRIPTION
In ExpressJS 4.x there's the route shortcut that lets you to add HTTP method handlers for a specific route.
I've just added this capability to Martini's router, for each HTTP method.
With this feature it will possible to define routes like in the following example:

```go
app := martini.Classic()
app.Route("/hello").Get(func() string {
  return "GET World"
}).Post(func() string {
  return "POST World"
})
```

GET and POST handlers are now attached to the "/hello" route.

For more info: http://expressjs.com/4x/api.html#router.route