### PR TITLE
Expose matched Route to middleware

### DIFF
--- a/router.go
+++ b/router.go
@@ -45,7 +45,7 @@ type Router interface {
 
 	// GetMatchedRoute will return a Martini route if a can be found
 	// given a METHOD and path. If none can be found, nil is returned
-	GetMatchedRoute(string, string) route
+	GetMatchedRoute(string, string) *route
 }
 
 type router struct {
@@ -134,7 +134,7 @@ func (r *router) Handle(res http.ResponseWriter, req *http.Request, context Cont
 
 // GetMatchedRoute will return a Martini route if a can be found
 // given a METHOD and path. If none can be found, nil is returned
-func (r *router) GetMatchedRoute(method string, path string) route {
+func (r *router) GetMatchedRoute(method string, path string) *route {
 	for _, route := range r.routes {
 		ok, _ := route.Match(method, path)
 		if ok {

--- a/router.go
+++ b/router.go
@@ -43,8 +43,8 @@ type Router interface {
 	// Handle is the entry point for routing. This is used as a martini.Handler
 	Handle(http.ResponseWriter, *http.Request, Context)
 
-	// GetMatchedRoute will return a Martini route if a can be found
-	// given a METHOD and path. If none can be found, nil is returned
+	// GetMatchedRoute will return a Martini route if one is found
+	// given a method and path. If no route is found, nil is returned
 	GetMatchedRoute(string, string) Route
 }
 
@@ -132,8 +132,8 @@ func (r *router) Handle(res http.ResponseWriter, req *http.Request, context Cont
 	c.run()
 }
 
-// GetMatchedRoute will return a Martini route if a can be found
-// given a METHOD and path. If none can be found, nil is returned
+// GetMatchedRoute will return a Martini route if one is found
+// given a method and path. If no route is found, nil is returned
 func (r *router) GetMatchedRoute(method string, path string) Route {
 	for _, route := range r.routes {
 		ok, _ := route.Match(method, path)

--- a/router.go
+++ b/router.go
@@ -42,6 +42,10 @@ type Router interface {
 
 	// Handle is the entry point for routing. This is used as a martini.Handler
 	Handle(http.ResponseWriter, *http.Request, Context)
+
+	// GetMatchedRoute will return a Martini route if a can be found
+	// given a METHOD and path. If none can be found, nil is returned
+	GetMatchedRoute(string, string) route
 }
 
 type router struct {
@@ -126,6 +130,19 @@ func (r *router) Handle(res http.ResponseWriter, req *http.Request, context Cont
 	c := &routeContext{context, 0, r.notFounds}
 	context.MapTo(c, (*Context)(nil))
 	c.run()
+}
+
+// GetMatchedRoute will return a Martini route if a can be found
+// given a METHOD and path. If none can be found, nil is returned
+func (r *router) GetMatchedRoute(method string, path string) route {
+	for _, route := range r.routes {
+		ok, _ := route.Match(method, path)
+		if ok {
+			return route
+		}
+	}
+
+	return nil
 }
 
 func (r *router) NotFound(handler ...Handler) {

--- a/router.go
+++ b/router.go
@@ -45,7 +45,7 @@ type Router interface {
 
 	// GetMatchedRoute will return a Martini route if a can be found
 	// given a METHOD and path. If none can be found, nil is returned
-	GetMatchedRoute(string, string) *route
+	GetMatchedRoute(string, string) Route
 }
 
 type router struct {
@@ -134,7 +134,7 @@ func (r *router) Handle(res http.ResponseWriter, req *http.Request, context Cont
 
 // GetMatchedRoute will return a Martini route if a can be found
 // given a METHOD and path. If none can be found, nil is returned
-func (r *router) GetMatchedRoute(method string, path string) *route {
+func (r *router) GetMatchedRoute(method string, path string) Route {
 	for _, route := range r.routes {
 		ok, _ := route.Match(method, path)
 		if ok {

--- a/router_test.go
+++ b/router_test.go
@@ -479,12 +479,12 @@ func Test_GetMatchedRoute_NoMatch(t *testing.T) {
 
 func Test_GetMatchedRoute_Match(t *testing.T) {
 	router := NewRouter()
-	router.Get("/foo", func() {
-	}).Name("Foo")
+	expected := router.Get("/foo", func() {
+	})
+	expected.Name("Foo")
 
 	route := router.GetMatchedRoute("GET", "/foo")
-
 	if route == nil || route.GetName() != "Foo" {
-		t.Errorf("expected: (%v) got: (%v)", route, route)
+		t.Errorf("expected: (%v) got: (%v)", expected, route)
 	}
 }

--- a/router_test.go
+++ b/router_test.go
@@ -466,3 +466,25 @@ func Test_ActiveRoute(t *testing.T) {
 	context.MapTo(router, (*Routes)(nil))
 	router.Handle(recorder, req, context)
 }
+
+func Test_GetMatchedRoute_NoMatch(t *testing.T) {
+	router := NewRouter()
+
+	route := router.GetMatchedRoute("GET", "/foo")
+
+	if route != nil {
+		t.Errorf("expected: (nil) got: (%v)", route)
+	}
+}
+
+func Test_GetMatchedRoute_Match(t *testing.T) {
+	router := NewRouter()
+	router.Get("/foo", func() {
+	}).Name("Foo")
+
+	route := router.GetMatchedRoute("GET", "/foo")
+
+	if route == nil || route.GetName() != "Foo" {
+		t.Errorf("expected: (%v) got: (%v)", route, route)
+	}
+}


### PR DESCRIPTION
This pull request adds a `GetMatchedRoute()` method to the `Route` interface.

I added this as I couldn't see any easier way to get a route (since everything is private) inside of middleware. For instance, now you're able to get the route name inside of middleware:

```go
m.Use(func(res http.ResponseWriter, req *http.Request, c martini.Context) {
	rw := res.(martini.ResponseWriter)
	c.Next()
	route := router.GetMatchedRoute(req.Method, req.URL.Path)
	if route != nil {
		fmt.Printf("Route name: %s", route.GetName())
	}
})
```

Concerns:
- If someone has their own implementation of the `Route` interface, this could break backwards compatibility for them until they add the method to their implementation.

Let me know if I missed something obvious or there are any problems with this pull request.