### PR TITLE
Unexpected 404 in route with named parameters and special characters

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -239,6 +239,7 @@ var routeTests = []struct {
 	match  RouteMatch
 	params map[string]string
 }{
+	{"GET", "/foo/123?/bat/321", ExactMatch, map[string]string{"bar": "123?", "baz": "321"}},
 	{"GET", "/foo/123/bat/321", ExactMatch, map[string]string{"bar": "123", "baz": "321"}},
 	{"POST", "/foo/123/bat/321", NoMatch, map[string]string{}},
 	{"GET", "/foo/hello/bat/world", ExactMatch, map[string]string{"bar": "hello", "baz": "world"}},


### PR DESCRIPTION
Right now we're running into a problem where when a route with a named parameter exists, sending a parameter value that includes a URL encoded character of any of: `/#?` will 404 instead of the expected result of having that URL decoded character in the parameter value.

For more exact specifics, assuming the following route:

``` go
router := martini.NewRouter()
route.Get("/foo/:bar", FooHandler)
```

It would be expected that sending the following request: `curl -X GET "http://localhost/foo/hello%3F"` would result in an ExactMatch on route for the FooHandler with a `martini.Params` map of `params[bar] = "hello?"`

However, the current result is simply a 404 which shows that no route was found. It seems like this line is the reason: https://github.com/go-martini/martini/blob/master/router.go#L216

I've added a test in this PR that currently fails due to this problem. Is there a specific reason why `/#?` is not allowed in route parameters? Are there any ideas on how we can fix this problem?
