### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Start by looking in the [martini-contrib](https://github.com/martini-contrib) pr
 * [encoder](https://github.com/martini-contrib/encoder) - Encoder service for rendering data in several formats and content negotiation.
 * [gzip](https://github.com/martini-contrib/gzip) - Handler for adding gzip compress to requests
 * [gorelic](https://github.com/martini-contrib/gorelic) - NewRelic middleware
-* [logstasher](https://github.com/martini-contrib/logstasher) - Middleware that prints logstash-compatiable JSON 
+* [logstasher](https://github.com/martini-contrib/logstasher) - Middleware that prints logstash-compatible JSON 
 * [method](https://github.com/martini-contrib/method) - HTTP method overriding via Header or form fields.
 * [oauth2](https://github.com/martini-contrib/oauth2) - Handler that provides OAuth 2.0 login for Martini apps. Google Sign-in, Facebook Connect and Github login is supported.
 * [permissions2](https://github.com/xyproto/permissions2) - Handler for keeping track of users, login states and permissions.


### PR DESCRIPTION
@go-martini, I've corrected a typographical error in the documentation of the [martini](https://github.com/go-martini/martini) project. Specifically, I've changed compatiable to compatible. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.