### PR TITLE
Properly support closenotifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,29 @@ _testmain.go
 # Godeps
 Godeps/_workspace
 Godeps/Readme
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+.idea/
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties

--- a/response_writer.go
+++ b/response_writer.go
@@ -30,7 +30,11 @@ type BeforeFunc func(ResponseWriter)
 
 // NewResponseWriter creates a ResponseWriter that wraps an http.ResponseWriter
 func NewResponseWriter(rw http.ResponseWriter) ResponseWriter {
-	return &responseWriter{rw, 0, 0, nil}
+	newRw := responseWriter{rw, 0, 0, nil}
+	if cn, ok := rw.(http.CloseNotifier); ok {
+		return &closeNotifyResponseWriter{newRw, cn}
+	}
+	return &newRw
 }
 
 type responseWriter struct {
@@ -80,10 +84,6 @@ func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return hijacker.Hijack()
 }
 
-func (rw *responseWriter) CloseNotify() <-chan bool {
-	return rw.ResponseWriter.(http.CloseNotifier).CloseNotify()
-}
-
 func (rw *responseWriter) callBefore() {
 	for i := len(rw.beforeFuncs) - 1; i >= 0; i-- {
 		rw.beforeFuncs[i](rw)
@@ -95,4 +95,13 @@ func (rw *responseWriter) Flush() {
 	if ok {
 		flusher.Flush()
 	}
+}
+
+type closeNotifyResponseWriter struct {
+	responseWriter
+	closeNotifier http.CloseNotifier
+}
+
+func (rw *closeNotifyResponseWriter) CloseNotify() <-chan bool {
+	return rw.closeNotifier.CloseNotify()
 }


### PR DESCRIPTION
According to [the golang docs](https://golang.org/pkg/net/http/#CloseNotifier):

    The CloseNotifier interface is implemented by ResponseWriters which allow detecting when the underlying connection has gone away.

This appears to be an optional interface of ResponseWriter, but martini is treating it as if it's always available. In this change, the function that constructs the martini ResponseWriter wrapper checks to see if the provided http.ResponseWriter implements the CloseNotifier interface. If it does, then the returned wrapper will implement CloseNotifier as a pass-through.